### PR TITLE
Add sample slicing and editing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ python app.py
 
 Open the local URL shown to use the UI. Drop some samples in `samples/` and start prompting.
 
+## Supported Commands
+
+Synthtax mixes are built from simple text commands:
+
+- `load DRUM from "path.wav"` — load a sample
+- `loop(track, bars=2)` — loop a track for a number of bars
+- `gain(track, db)` — adjust volume in dB
+- `fadeIn(track, seconds=2)` / `fadeOut(track, seconds=2)` — fade transitions
+- `slice(track, start=0, duration=500)` — grab a mini-sample
+- `reverse(track)` — reverse a track
+- `reverb(track, amount=0.5)` — add simple reverb
+- `export("mix.wav")` — write the final mix
+
 ## FFmpeg
 Install FFmpeg and make sure it's on your PATH. Or set `FFMPEG_PATH` in `app.py`.
 

--- a/core/fx.py
+++ b/core/fx.py
@@ -19,6 +19,19 @@ def fade_in(segment: AudioSegment, seconds: int) -> AudioSegment:
     """Fade in the segment."""
     return segment.fade_in(seconds * 1000)
 
+def fade_out(segment: AudioSegment, seconds: int) -> AudioSegment:
+    """Fade out the segment."""
+    return segment.fade_out(seconds * 1000)
+
+def slice_segment(segment: AudioSegment, start_ms: int, duration_ms: int) -> AudioSegment:
+    """Extract a portion of the segment."""
+    end_ms = start_ms + duration_ms
+    return segment[start_ms:end_ms]
+
+def reverse(segment: AudioSegment) -> AudioSegment:
+    """Reverse the audio segment."""
+    return segment.reverse()
+
 def reverb(segment: AudioSegment, amount: float = 0.5) -> AudioSegment:
     """Simple reverb using delayed attenuated copies with numpy."""
     samples = np.array(segment.get_array_of_samples()).astype(np.float32)

--- a/core/parser.py
+++ b/core/parser.py
@@ -48,6 +48,24 @@ def parse(text: str) -> List[Dict]:
                 raise ValueError(f"Invalid fadeIn syntax: {line}")
             track, secs = m.groups()
             commands.append({'action': 'fadeIn', 'track': track, 'seconds': int(secs)})
+        elif line.startswith('fadeOut'):
+            m = re.match(r'fadeOut\(\s*(\w+),\s*seconds\s*=\s*(\d+)\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid fadeOut syntax: {line}")
+            track, secs = m.groups()
+            commands.append({'action': 'fadeOut', 'track': track, 'seconds': int(secs)})
+        elif line.startswith('slice'):
+            m = re.match(r'slice\(\s*(\w+),\s*start\s*=\s*(\d+),\s*duration\s*=\s*(\d+)\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid slice syntax: {line}")
+            track, start, dur = m.groups()
+            commands.append({'action': 'slice', 'track': track, 'start': int(start), 'duration': int(dur)})
+        elif line.startswith('reverse'):
+            m = re.match(r'reverse\(\s*(\w+)\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid reverse syntax: {line}")
+            track = m.group(1)
+            commands.append({'action': 'reverse', 'track': track})
         elif line.startswith('reverb'):
             m = re.match(r'reverb\(\s*(\w+),\s*amount\s*=\s*([0-9.]+)\s*\)', line)
             if not m:
@@ -85,6 +103,12 @@ def from_yaml(yaml_text: str) -> str:
             lines.append(f"gain({cmd['track']}, {cmd['db']})")
         elif act == 'fadeIn':
             lines.append(f"fadeIn({cmd['track']}, seconds={cmd['seconds']})")
+        elif act == 'fadeOut':
+            lines.append(f"fadeOut({cmd['track']}, seconds={cmd['seconds']})")
+        elif act == 'slice':
+            lines.append(f"slice({cmd['track']}, start={cmd['start']}, duration={cmd['duration']})")
+        elif act == 'reverse':
+            lines.append(f"reverse({cmd['track']})")
         elif act == 'reverb':
             lines.append(f"reverb({cmd['track']}, amount={cmd['amount']})")
         elif act == 'export':

--- a/core/render.py
+++ b/core/render.py
@@ -28,6 +28,18 @@ def apply_commands(commands: List[Dict], uploaded_path: Optional[str] = None, pr
             seg = tracks.get(cmd['track'])
             if seg is not None:
                 tracks[cmd['track']] = fx.fade_in(seg, cmd['seconds'])
+        elif action == 'fadeOut':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.fade_out(seg, cmd['seconds'])
+        elif action == 'slice':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.slice_segment(seg, cmd['start'], cmd['duration'])
+        elif action == 'reverse':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.reverse(seg)
         elif action == 'reverb':
             seg = tracks.get(cmd['track'])
             if seg is not None:


### PR DESCRIPTION
## Summary
- add new audio effects: slice, fadeOut, reverse
- document supported Synthtax commands

## Testing
- `python -m py_compile core/fx.py core/parser.py core/render.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c582564c148329adf9f9dc66789145