### PR TITLE
Add pan effect with parser and rendering support

### DIFF
--- a/core/fx.py
+++ b/core/fx.py
@@ -32,6 +32,10 @@ def reverse(segment: AudioSegment) -> AudioSegment:
     """Reverse the audio segment."""
     return segment.reverse()
 
+def pan(segment: AudioSegment, amount: float) -> AudioSegment:
+    """Pan the audio segment left (-1.0) to right (1.0)."""
+    return segment.pan(amount)
+
 def reverb(segment: AudioSegment, amount: float = 0.5) -> AudioSegment:
     """Simple reverb using delayed attenuated copies with numpy."""
     samples = np.array(segment.get_array_of_samples()).astype(np.float32)

--- a/core/parser.py
+++ b/core/parser.py
@@ -66,6 +66,12 @@ def parse(text: str) -> List[Dict]:
                 raise ValueError(f"Invalid reverse syntax: {line}")
             track = m.group(1)
             commands.append({'action': 'reverse', 'track': track})
+        elif line.startswith('pan'):
+            m = re.match(r'pan\(\s*(\w+),\s*amount\s*=\s*(-?[0-9.]+)\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid pan syntax: {line}")
+            track, amt = m.groups()
+            commands.append({'action': 'pan', 'track': track, 'amount': float(amt)})
         elif line.startswith('reverb'):
             m = re.match(r'reverb\(\s*(\w+),\s*amount\s*=\s*([0-9.]+)\s*\)', line)
             if not m:
@@ -109,6 +115,8 @@ def from_yaml(yaml_text: str) -> str:
             lines.append(f"slice({cmd['track']}, start={cmd['start']}, duration={cmd['duration']})")
         elif act == 'reverse':
             lines.append(f"reverse({cmd['track']})")
+        elif act == 'pan':
+            lines.append(f"pan({cmd['track']}, amount={cmd['amount']})")
         elif act == 'reverb':
             lines.append(f"reverb({cmd['track']}, amount={cmd['amount']})")
         elif act == 'export':

--- a/core/render.py
+++ b/core/render.py
@@ -40,6 +40,10 @@ def apply_commands(commands: List[Dict], uploaded_path: Optional[str] = None, pr
             seg = tracks.get(cmd['track'])
             if seg is not None:
                 tracks[cmd['track']] = fx.reverse(seg)
+        elif action == 'pan':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.pan(seg, cmd['amount'])
         elif action == 'reverb':
             seg = tracks.get(cmd['track'])
             if seg is not None:

--- a/tests/test_pan.py
+++ b/tests/test_pan.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pydub.generators import Sine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core import parser, fx
+
+
+def test_parse_pan_roundtrip():
+    text = "pan(DRUM, amount=-0.25)"
+    cmds = parser.parse(text)
+    assert cmds == [{'action': 'pan', 'track': 'DRUM', 'amount': -0.25}]
+    yaml_text = parser.to_yaml(text)
+    assert parser.from_yaml(yaml_text).strip() == text
+
+
+def test_fx_pan_left_channel():
+    seg = Sine(440).to_audio_segment(duration=1000).set_channels(2)
+    panned = fx.pan(seg, -1.0)
+    left, right = panned.split_to_mono()
+    assert right.dBFS < -50
+    assert left.dBFS > right.dBFS


### PR DESCRIPTION
## Summary
- support `pan(track, amount)` command in parser, renderer and effects
- cover pan parsing and audio behavior with unit tests

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ccd687f483298b12f2ff4a1b8832