### PR TITLE
Add normalize audio effect and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Synthtax mixes are built from simple text commands:
 - `fadeIn(track, seconds=2)` / `fadeOut(track, seconds=2)` — fade transitions
 - `slice(track, start=0, duration=500)` — grab a mini-sample
 - `reverse(track)` — reverse a track
+- `pan(track, amount=-1.0..1.0)` — pan left/right
 - `reverb(track, amount=0.5)` — add simple reverb
+- `normalize(track, headroom=0.1)` — normalize level
 - `export("mix.wav")` — write the final mix
 
 ## FFmpeg

--- a/core/fx.py
+++ b/core/fx.py
@@ -36,6 +36,11 @@ def pan(segment: AudioSegment, amount: float) -> AudioSegment:
     """Pan the audio segment left (-1.0) to right (1.0)."""
     return segment.pan(amount)
 
+def normalize(segment: AudioSegment, headroom: float = 0.1) -> AudioSegment:
+    """Normalize audio to a target headroom in dBFS."""
+    change = -segment.max_dBFS - headroom
+    return segment.apply_gain(change)
+
 def reverb(segment: AudioSegment, amount: float = 0.5) -> AudioSegment:
     """Simple reverb using delayed attenuated copies with numpy."""
     samples = np.array(segment.get_array_of_samples()).astype(np.float32)

--- a/core/parser.py
+++ b/core/parser.py
@@ -72,6 +72,15 @@ def parse(text: str) -> List[Dict]:
                 raise ValueError(f"Invalid pan syntax: {line}")
             track, amt = m.groups()
             commands.append({'action': 'pan', 'track': track, 'amount': float(amt)})
+        elif line.startswith('normalize'):
+            m = re.match(r'normalize\(\s*(\w+)(?:,\s*headroom\s*=\s*([0-9.]+))?\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid normalize syntax: {line}")
+            track, headroom = m.groups()
+            cmd = {'action': 'normalize', 'track': track}
+            if headroom is not None:
+                cmd['headroom'] = float(headroom)
+            commands.append(cmd)
         elif line.startswith('reverb'):
             m = re.match(r'reverb\(\s*(\w+),\s*amount\s*=\s*([0-9.]+)\s*\)', line)
             if not m:
@@ -117,6 +126,11 @@ def from_yaml(yaml_text: str) -> str:
             lines.append(f"reverse({cmd['track']})")
         elif act == 'pan':
             lines.append(f"pan({cmd['track']}, amount={cmd['amount']})")
+        elif act == 'normalize':
+            if 'headroom' in cmd:
+                lines.append(f"normalize({cmd['track']}, headroom={cmd['headroom']})")
+            else:
+                lines.append(f"normalize({cmd['track']})")
         elif act == 'reverb':
             lines.append(f"reverb({cmd['track']}, amount={cmd['amount']})")
         elif act == 'export':

--- a/core/render.py
+++ b/core/render.py
@@ -44,6 +44,10 @@ def apply_commands(commands: List[Dict], uploaded_path: Optional[str] = None, pr
             seg = tracks.get(cmd['track'])
             if seg is not None:
                 tracks[cmd['track']] = fx.pan(seg, cmd['amount'])
+        elif action == 'normalize':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.normalize(seg, cmd.get('headroom', 0.1))
         elif action == 'reverb':
             seg = tracks.get(cmd['track'])
             if seg is not None:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+from pydub.generators import Sine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core import parser, fx
+
+
+def test_parse_normalize_roundtrip():
+    text = "normalize(DRUM, headroom=0.5)"
+    cmds = parser.parse(text)
+    assert cmds == [{'action': 'normalize', 'track': 'DRUM', 'headroom': 0.5}]
+    yaml_text = parser.to_yaml(text)
+    assert parser.from_yaml(yaml_text).strip() == text
+
+
+def test_fx_normalize_increases_level():
+    seg = Sine(440).to_audio_segment(duration=1000) - 10
+    assert seg.max_dBFS < -9  # ensure reduction
+    normed = fx.normalize(seg, headroom=0.0)
+    assert normed.max_dBFS == pytest.approx(0, abs=0.1)
+


### PR DESCRIPTION
## Summary
- add normalize effect for audio segments with configurable headroom
- parse and render new `normalize` command and document supported `pan`/`normalize`
- test normalization round-trip and signal gain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c0cae90c8329a704202b5bc36ce7