### PR TITLE
Add low-pass filter effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Synthtax mixes are built from simple text commands:
 - `slice(track, start=0, duration=500)` — grab a mini-sample
 - `reverse(track)` — reverse a track
 - `reverb(track, amount=0.5)` — add simple reverb
+- `pan(track, amount=-0.5)` — pan left/right (-1.0 to 1.0)
+- `lowPass(track, cutoff=2000)` — apply a low-pass filter
 - `export("mix.wav")` — write the final mix
 
 ## FFmpeg

--- a/core/fx.py
+++ b/core/fx.py
@@ -36,6 +36,10 @@ def pan(segment: AudioSegment, amount: float) -> AudioSegment:
     """Pan the audio segment left (-1.0) to right (1.0)."""
     return segment.pan(amount)
 
+def low_pass(segment: AudioSegment, cutoff: int) -> AudioSegment:
+    """Apply a low-pass filter with the given cutoff frequency."""
+    return segment.low_pass_filter(cutoff)
+
 def reverb(segment: AudioSegment, amount: float = 0.5) -> AudioSegment:
     """Simple reverb using delayed attenuated copies with numpy."""
     samples = np.array(segment.get_array_of_samples()).astype(np.float32)

--- a/core/parser.py
+++ b/core/parser.py
@@ -72,6 +72,12 @@ def parse(text: str) -> List[Dict]:
                 raise ValueError(f"Invalid pan syntax: {line}")
             track, amt = m.groups()
             commands.append({'action': 'pan', 'track': track, 'amount': float(amt)})
+        elif line.startswith('lowPass'):
+            m = re.match(r'lowPass\(\s*(\w+),\s*cutoff\s*=\s*(\d+)\s*\)', line)
+            if not m:
+                raise ValueError(f"Invalid lowPass syntax: {line}")
+            track, cutoff = m.groups()
+            commands.append({'action': 'lowPass', 'track': track, 'cutoff': int(cutoff)})
         elif line.startswith('reverb'):
             m = re.match(r'reverb\(\s*(\w+),\s*amount\s*=\s*([0-9.]+)\s*\)', line)
             if not m:
@@ -117,6 +123,8 @@ def from_yaml(yaml_text: str) -> str:
             lines.append(f"reverse({cmd['track']})")
         elif act == 'pan':
             lines.append(f"pan({cmd['track']}, amount={cmd['amount']})")
+        elif act == 'lowPass':
+            lines.append(f"lowPass({cmd['track']}, cutoff={cmd['cutoff']})")
         elif act == 'reverb':
             lines.append(f"reverb({cmd['track']}, amount={cmd['amount']})")
         elif act == 'export':

--- a/core/render.py
+++ b/core/render.py
@@ -44,6 +44,10 @@ def apply_commands(commands: List[Dict], uploaded_path: Optional[str] = None, pr
             seg = tracks.get(cmd['track'])
             if seg is not None:
                 tracks[cmd['track']] = fx.pan(seg, cmd['amount'])
+        elif action == 'lowPass':
+            seg = tracks.get(cmd['track'])
+            if seg is not None:
+                tracks[cmd['track']] = fx.low_pass(seg, cmd['cutoff'])
         elif action == 'reverb':
             seg = tracks.get(cmd['track'])
             if seg is not None:

--- a/tests/test_lowpass.py
+++ b/tests/test_lowpass.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pydub.generators import Sine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core import parser, fx
+
+
+def test_parse_lowpass_roundtrip():
+    text = "lowPass(DRUM, cutoff=1000)"
+    cmds = parser.parse(text)
+    assert cmds == [{'action': 'lowPass', 'track': 'DRUM', 'cutoff': 1000}]
+    yaml_text = parser.to_yaml(text)
+    assert parser.from_yaml(yaml_text).strip() == text
+
+
+def test_fx_lowpass_reduces_high_freq():
+    seg = Sine(5000).to_audio_segment(duration=1000)
+    filtered = fx.low_pass(seg, 1000)
+    assert filtered.dBFS < seg.dBFS - 10
+


### PR DESCRIPTION
## Summary
- support lowPass command in parser and renderer
- implement low_pass audio effect and document usage
- add tests for low-pass filtering and document pan command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7248fc82c8329b6138784dbff5f0e