### PR TITLE
feat: add bpm control to ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ python app.py
 ```
 
 Open the local URL shown to use the UI. Drop some samples in `samples/` and start prompting.
+The interface includes a BPM slider so you can quickly adjust the tempo of the generated mix.
 
 ## Supported Commands
 

--- a/app/engine.py
+++ b/app/engine.py
@@ -98,12 +98,13 @@ def make_pad(
 # Prompt -> recipe
 
 
-def generate_recipe_from_prompt(prompt: str) -> Dict:
+def generate_recipe_from_prompt(prompt: str, override_bpm: int | None = None) -> Dict:
     """Return a minimal recipe dict derived from ``prompt``.
 
     The prompt is scanned for simple style keywords.  Each style controls the
     BPM, hi‑hat density and pad waveform so that different prompts yield
-    noticeably different audio.
+    noticeably different audio.  If ``override_bpm`` is provided it will replace
+    the style's default tempo so the user can fine tune the speed of the mix.
     """
 
     text = prompt.lower()
@@ -144,6 +145,9 @@ def generate_recipe_from_prompt(prompt: str) -> Dict:
         recipe["pad_reverb"] = True
     else:
         recipe["pad_reverb"] = False
+
+    if override_bpm is not None:
+        recipe["bpm"] = override_bpm
 
     return recipe
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -43,10 +43,10 @@ def _waveform_html(audio_b64: str) -> str:
     """
 
 
-def _preview_from_prompt(prompt: str) -> Tuple[Tuple[int, bytes], str, str]:
-    """Build track from prompt and return audio bytes, YAML recipe and visualizer."""
+def _preview_from_prompt(prompt: str, bpm: int) -> Tuple[Tuple[int, bytes], str, str]:
+    """Build track from ``prompt`` and ``bpm`` returning audio bytes, YAML recipe and visualizer."""
 
-    recipe = generate_recipe_from_prompt(prompt)
+    recipe = generate_recipe_from_prompt(prompt, override_bpm=bpm)
     track = build_track(recipe)
     buf = io.BytesIO()
     track.export(buf, format="wav")
@@ -55,10 +55,10 @@ def _preview_from_prompt(prompt: str) -> Tuple[Tuple[int, bytes], str, str]:
     return (track.frame_rate, audio_bytes), yaml.safe_dump(recipe), _waveform_html(audio_b64)
 
 
-def _export_from_prompt(prompt: str) -> str:
+def _export_from_prompt(prompt: str, bpm: int) -> str:
     """Render and export the track to ``out/synthtax_demo.wav``."""
 
-    recipe = generate_recipe_from_prompt(prompt)
+    recipe = generate_recipe_from_prompt(prompt, override_bpm=bpm)
     track = build_track(recipe)
     out_dir = "out"
     os.makedirs(out_dir, exist_ok=True)
@@ -77,6 +77,7 @@ def launch_app() -> gr.Blocks:
             value=DEFAULT_PROMPT,
             placeholder="Describe the vibe or mood",
         )
+        bpm = gr.Slider(60, 160, value=120, step=1, label="BPM")
 
         with gr.Row():
             for label, text in PRESETS.items():
@@ -98,9 +99,9 @@ def launch_app() -> gr.Blocks:
         file_out = gr.File(label="Download")
 
         preview_btn.click(
-            _preview_from_prompt, inputs=prompt, outputs=[audio, code, visual]
+            _preview_from_prompt, inputs=[prompt, bpm], outputs=[audio, code, visual]
         )
-        export_btn.click(_export_from_prompt, inputs=prompt, outputs=file_out)
+        export_btn.click(_export_from_prompt, inputs=[prompt, bpm], outputs=file_out)
 
     return demo
 


### PR DESCRIPTION
## Summary
- Add BPM slider to UI allowing tempo customization
- Support override BPM in recipe generation
- Document tempo control in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c81bb678dc83298b8ebf958c72c83f