### PR TITLE
Add beat command for auto-generated drum grooves

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Synthtax mixes are built from simple text commands:
 - `reverse(track)` — reverse a track
 - `pan(track, amount=-1.0..1.0)` — pan left/right
 - `reverb(track, amount=0.5)` — add simple reverb
+- `beat(track, style="house", bars=4)` — synthesize a drum groove (house/hiphop/breakbeat)
 - `normalize(track, headroom=0.1)` — normalize level
 - `export("mix.wav")` — write the final mix
 

--- a/core/fx.py
+++ b/core/fx.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, List
 import numpy as np
 from pydub import AudioSegment
 
@@ -53,3 +53,100 @@ def reverb(segment: AudioSegment, amount: float = 0.5) -> AudioSegment:
     # clip to int16 range
     out = np.clip(out, -32768, 32767).astype(np.int16)
     return segment._spawn(out.tobytes())
+
+
+def _to_segment(samples: np.ndarray, frame_rate: int) -> AudioSegment:
+    """Convert floating point samples (-1..1) to an AudioSegment."""
+    clipped = np.clip(samples, -1.0, 1.0)
+    int_samples = (clipped * 32767).astype(np.int16)
+    return AudioSegment(
+        data=int_samples.tobytes(), sample_width=2, frame_rate=frame_rate, channels=1
+    )
+
+
+def _kick(frame_rate: int) -> AudioSegment:
+    duration_ms = 240
+    t = np.linspace(0, duration_ms / 1000.0, int(frame_rate * duration_ms / 1000.0), False)
+    freq_start, freq_end = 120.0, 50.0
+    freq = freq_start * (freq_end / freq_start) ** (t / t.max())
+    envelope = np.exp(-6 * t)
+    wave = np.sin(2 * np.pi * freq * t) * envelope
+    segment = _to_segment(wave, frame_rate)
+    return segment.fade_out(80)
+
+
+def _snare(frame_rate: int) -> AudioSegment:
+    duration_ms = 180
+    n_samples = int(frame_rate * duration_ms / 1000.0)
+    rng = np.random.default_rng(42)
+    noise = rng.uniform(-1.0, 1.0, n_samples)
+    envelope = np.exp(-10 * np.linspace(0, 1, n_samples))
+    wave = noise * envelope
+    segment = _to_segment(wave, frame_rate)
+    return segment.high_pass_filter(2000).fade_out(60)
+
+
+def _hat(frame_rate: int) -> AudioSegment:
+    duration_ms = 120
+    n_samples = int(frame_rate * duration_ms / 1000.0)
+    rng = np.random.default_rng(99)
+    noise = rng.uniform(-1.0, 1.0, n_samples)
+    envelope = np.exp(-12 * np.linspace(0, 1, n_samples))
+    wave = noise * envelope
+    segment = _to_segment(wave, frame_rate).high_pass_filter(6000)
+    return segment.fade_out(40)
+
+
+def _drum_kit(frame_rate: int) -> Dict[str, AudioSegment]:
+    return {
+        "kick": _kick(frame_rate),
+        "snare": _snare(frame_rate),
+        "hat": _hat(frame_rate),
+    }
+
+
+BEAT_PATTERNS: Dict[str, Dict[str, List[int]]] = {
+    "house": {
+        "kick": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+        "snare": [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+        "hat": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+    },
+    "hiphop": {
+        "kick": [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0],
+        "snare": [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+        "hat": [0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1],
+    },
+    "breakbeat": {
+        "kick": [1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0],
+        "snare": [0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0],
+        "hat": [0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1],
+    },
+}
+
+
+def generate_beat(style: str, bars: int, bpm: int, frame_rate: int = 44100) -> AudioSegment:
+    """Generate a simple beat pattern using synthesized drum sounds."""
+
+    if bars <= 0:
+        raise ValueError("bars must be positive for beat generation")
+
+    pattern = BEAT_PATTERNS.get(style, BEAT_PATTERNS["house"])
+    kit = _drum_kit(frame_rate)
+
+    steps_per_bar = len(next(iter(pattern.values())))
+    bar_ms = 60000 / bpm * 4
+    step_ms = bar_ms / steps_per_bar
+    total_ms = int(bar_ms * bars)
+
+    beat = AudioSegment.silent(duration=total_ms + 5, frame_rate=frame_rate)
+
+    for instrument, steps in pattern.items():
+        sample = kit[instrument]
+        for bar_index in range(bars):
+            for step_index, active in enumerate(steps):
+                if not active:
+                    continue
+                position = int((bar_index * steps_per_bar + step_index) * step_ms)
+                beat = beat.overlay(sample, position=position)
+
+    return normalize(beat, headroom=1.5)

--- a/core/render.py
+++ b/core/render.py
@@ -48,6 +48,12 @@ def apply_commands(commands: List[Dict], uploaded_path: Optional[str] = None, pr
             seg = tracks.get(cmd['track'])
             if seg is not None:
                 tracks[cmd['track']] = fx.normalize(seg, cmd.get('headroom', 0.1))
+        elif action == 'beat':
+            tracks[cmd['track']] = fx.generate_beat(
+                style=cmd.get('style', 'house'),
+                bars=cmd.get('bars', 4),
+                bpm=context.get('bpm', 120),
+            )
         elif action == 'reverb':
             seg = tracks.get(cmd['track'])
             if seg is not None:

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from core import fx, parser
+
+
+def test_parse_beat_command():
+    commands = parser.parse('beat(drums, style="hiphop", bars=3)')
+    assert commands[0] == {
+        'action': 'beat',
+        'track': 'drums',
+        'style': 'hiphop',
+        'bars': 3,
+    }
+
+
+def test_parse_beat_defaults():
+    commands = parser.parse('beat(groove, bars=2)')
+    cmd = commands[0]
+    assert cmd['style'] == 'house'
+    assert cmd['bars'] == 2
+
+
+def test_generate_beat_matches_bpm_and_bars():
+    bpm = 96
+    bars = 3
+    seg = fx.generate_beat('breakbeat', bars=bars, bpm=bpm)
+    expected_ms = int(60000 / bpm * 4 * bars)
+    assert abs(len(seg) - expected_ms) <= 20
+
+
+def test_generate_beat_requires_positive_bars():
+    with pytest.raises(ValueError):
+        fx.generate_beat('house', bars=0, bpm=120)

--- a/tests/test_prompt_to_synthtax.py
+++ b/tests/test_prompt_to_synthtax.py
@@ -27,3 +27,13 @@ def test_prompt_to_synthtax_basic():
         {'action': 'gain', 'track': 'DRUM', 'db': -3},
         {'action': 'export', 'file': 'out.wav'},
     ]
+
+
+def test_prompt_to_synthtax_with_beat():
+    prompt = "layer a hip hop beat and export to \"flip.wav\""
+    synth = parser.prompt_to_synthtax(prompt)
+    expected = '\n'.join([
+        'beat(drums, style="hiphop", bars=4)',
+        'export("flip.wav")',
+    ])
+    assert synth == expected

--- a/ui/app.py
+++ b/ui/app.py
@@ -22,6 +22,10 @@ PRESETS = {
         "recipe": """set(bpm=128, key=\"F#m\")\nload main from \"uploaded\"\nloop(main, bars=4)\ngain(main, 2)\nexport(\"dance_mix.wav\")""",
         "description": "High-energy club feel with extended loops and a confident lift in loudness.\n\n- Tempo: 128 BPM in F# minor\n- Four-bar repeating driver\n- Volume push to own the floor",
     },
+    "Remix Spark": {
+        "recipe": """set(bpm=100, key=\"Am\")\nload vox from \"uploaded\"\nslice(vox, start=0, duration=16000)\nloop(vox, bars=4)\nbeat(drums, style=\"hiphop\", bars=4)\ngain(drums, -2)\nexport(\"remix_flip.wav\")""",
+        "description": "Jump-start a remix with a looped vocal slice riding over a ready-made hip-hop beat.\n\n- Tempo: 100 BPM in A minor\n- Auto-generated drums in hip-hop style\n- Quick stem loop for chopping inspiration",
+    },
 }
 
 DEFAULT_PRESET = "Ambient Drift"
@@ -108,7 +112,7 @@ def build_ui() -> gr.Blocks:
                 audio_file = gr.File(label="Upload audio", file_types=["audio"])
                 with gr.Accordion("Need a quick syntax tour?", open=False):
                     gr.Markdown(
-                        """- `set(bpm=120, key=\"C\")` adjusts global tempo and key.\n- `load main from \"uploaded\"` grabs your uploaded file.\n- Effects like `reverb`, `gain`, and `loop` sculpt the vibe.\n- `export(\"mix.wav\")` saves the final bounce."""
+                        """- `set(bpm=120, key=\"C\")` adjusts global tempo and key.\n- `load main from \"uploaded\"` grabs your uploaded file.\n- `beat(drums, style=\"house\", bars=4)` adds an auto-generated drum groove.\n- Effects like `reverb`, `gain`, and `loop` sculpt the vibe.\n- `export(\"mix.wav\")` saves the final bounce."""
                     )
                 gr.Markdown(
                     """### 2. Choose a preset vibe\nExplore curated starting points before fine-tuning the recipe."""


### PR DESCRIPTION
## Summary
- introduce a `beat` Synthtax command and renderer support to synthesize drum grooves
- surface the new capability across the UI presets, helper text, and documentation
- cover the feature with parser, prompt, and beat synthesis tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb7421b87c832984be668df5247382